### PR TITLE
rd_parser_ebnf: fixed <power> ebnf on comments

### DIFF
--- a/2009/py_rd_parser_example/rd_parser_ebnf.py
+++ b/2009/py_rd_parser_example/rd_parser_ebnf.py
@@ -36,7 +36,7 @@
 # <term>        : <power> {* <power>}
 #               | <power> {/ <power>}
 #
-# <power>       : <power> ** <factor>
+# <power>       : <factor> ** <power>
 #               | <factor>
 #
 # <factor>      : <id> 


### PR DESCRIPTION
Now the `<power>` EBNF in the comments  is accidentally written as`<power>       : <power> ** <factor>`  