### PR TITLE
Simply replace eip with rip to make it works under x86 64 architecture

### DIFF
--- a/2011/simple_tracer_64.c
+++ b/2011/simple_tracer_64.c
@@ -1,0 +1,99 @@
+/* Code sample: using ptrace for simple tracing of a child process.
+**
+** Eli Bendersky (http://eli.thegreenplace.net)
+** This code is in the public domain.
+*/
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <syscall.h>
+#include <sys/ptrace.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/reg.h>
+#include <sys/user.h>
+#include <unistd.h>
+#include <errno.h>
+
+
+/* Print a message to stdout, prefixed by the process ID
+*/
+void procmsg(const char* format, ...)
+{
+    va_list ap;
+    fprintf(stdout, "[%d] ", getpid());
+    va_start(ap, format);
+    vfprintf(stdout, format, ap);
+    va_end(ap);
+}
+
+
+void run_target(const char* programname)
+{
+    procmsg("target started. will run '%s'\n", programname);
+
+    /* Allow tracing of this process */
+    if (ptrace(PTRACE_TRACEME, 0, 0, 0) < 0) {
+        perror("ptrace");
+        return;
+    }
+
+    /* Replace this process's image with the given program */
+    execl(programname, programname, 0);
+}
+
+
+void run_debugger(pid_t child_pid)
+{
+    int wait_status;
+    unsigned icounter = 0;
+    procmsg("debugger started\n");
+
+    /* Wait for child to stop on its first instruction */
+    wait(&wait_status);
+
+    while (WIFSTOPPED(wait_status)) {
+        icounter++;
+        struct user_regs_struct regs;
+        ptrace(PTRACE_GETREGS, child_pid, 0, &regs);
+        unsigned instr = ptrace(PTRACE_PEEKTEXT, child_pid, regs.rip, 0);
+ 
+        procmsg("icounter = %u.  EIP = 0x%08x.  instr = 0x%08x\n",
+                    icounter, regs.rip, instr);
+
+        /* Make the child execute another instruction */
+        if (ptrace(PTRACE_SINGLESTEP, child_pid, 0, 0) < 0) {
+            perror("ptrace");
+            return;
+        }
+
+        /* Wait for child to stop on its next instruction */
+        wait(&wait_status);
+    }
+
+    procmsg("the child executed %u instructions\n", icounter);
+}
+
+
+int main(int argc, char** argv)
+{
+    pid_t child_pid;
+
+    if (argc < 2) {
+        fprintf(stderr, "Expected a program name as argument\n");
+        return -1;
+    }
+
+    child_pid = fork();
+    if (child_pid == 0)
+        run_target(argv[1]);
+    else if (child_pid > 0)
+        run_debugger(child_pid);
+    else {
+        perror("fork");
+        return -1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Hi,

thank you very much for creating the tutorial about implementation of debugger. I add a new sample program (mostly copy paste) such that it could compile and work under x86 64 architecture. The old sample uses eip register for PC, I simply replace it with rip, which is the PC in 64 architecture.