### PR TITLE
Remove unused link option

### DIFF
--- a/2018/threadoverhead/Makefile
+++ b/2018/threadoverhead/Makefile
@@ -8,9 +8,6 @@ CCFLAGS = -std=gnu99 -Wall -O3 -g -DNDEBUG -pthread
 CXX = g++
 CXXFLAGS = -std=c++11 -Wall -O3 -g -DNDEBUG -pthread
 
-LDFLAGS = -lpthread
-
-
 EXECUTABLES = \
 	threadspammer \
 	malloc-memusage \


### PR DESCRIPTION
Hi Eli,

Maybe a nitpick. Since `-pthread` option can guarantee to link `libpthread`, adding `-lpthread` is totally unneed. Thanks!

Best Regards
Nan XIao