### PR TITLE
Remove redundant int cast on go-rest-servers/stdlib-basic

### DIFF
--- a/2021/go-rest-servers/stdlib-basic/stdlib-basic.go
+++ b/2021/go-rest-servers/stdlib-basic/stdlib-basic.go
@@ -56,9 +56,9 @@ func (ts *taskServer) taskHandler(w http.ResponseWriter, req *http.Request) {
 		}
 
 		if req.Method == http.MethodDelete {
-			ts.deleteTaskHandler(w, req, int(id))
+			ts.deleteTaskHandler(w, req, id)
 		} else if req.Method == http.MethodGet {
-			ts.getTaskHandler(w, req, int(id))
+			ts.getTaskHandler(w, req, id)
 		} else {
 			http.Error(w, fmt.Sprintf("expect method GET or DELETE at /task/<id>, got %v", req.Method), http.StatusMethodNotAllowed)
 			return


### PR DESCRIPTION
I'm guessing the `Atoi` call was added later on and these casts remained in the original code.