### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/2023/wasm-call-indirect/go-env/go.mod
+++ b/2023/wasm-call-indirect/go-env/go.mod
@@ -2,4 +2,4 @@ module example.com
 
 go 1.19
 
-require github.com/tetratelabs/wazero v1.0.0-pre.8
+require github.com/tetratelabs/wazero v1.0.1

--- a/2023/wasm-call-indirect/go-env/go.sum
+++ b/2023/wasm-call-indirect/go-env/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
-github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/2023/wasm-call-indirect/go-env/main.go
+++ b/2023/wasm-call-indirect/go-env/main.go
@@ -36,7 +36,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	tableWasm, err := r.InstantiateModuleFromBinary(ctx, wasmObj)
+	tableWasm, err := r.Instantiate(ctx, wasmObj)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.