### PR TITLE
Update using-adc.go

### DIFF
--- a/2024/go-docs-sheets-auth/using-adc.go
+++ b/2024/go-docs-sheets-auth/using-adc.go
@@ -3,7 +3,7 @@
 //
 // This assumes that you ran:
 //
-//	$ gcloud auth application-default login
+//	$ gcloud auth application-default login --scopes=openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets
 //
 // Also, the sheets API has to be enabled for your project:
 //


### PR DESCRIPTION
After running: `gcloud auth application-default login`, then 

Running the code from your blog using `go run using-adc.go`, it fails for me with:
```
2025/01/15 16:36:48 unable to retrieve data from document: googleapi: Error 403: Request had insufficient authentication scopes.
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
    "domain": "googleapis.com",
    "metadata": {
      "method": "google.apps.sheets.v4.SpreadsheetsService.GetSpreadsheet",
      "service": "sheets.googleapis.com"
    },
    "reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
  }
]

More details:
Reason: insufficientPermissions, Message: Insufficient Permission
exit status 1
```
However, if I adjust the application default login scopes to add a few non-default scopes, then running `go run using-adc.go` will work for me.

I tried changing the gsheet ID to one owned by me, but that didn't seem to make a difference, as it still required these additional scopes.

It took quite a bit of trial and error to figure out what was required to get this to work, and then I randomly came across a [this Python developer's comment in this Stackoverflow question](https://stackoverflow.com/a/72986975).

Thank you for your very helpful articles!